### PR TITLE
Update for compatibility with base 3.15 and recent versions of the motor module

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -31,3 +31,7 @@ CHECK_RELEASE = YES
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+# Define the ssh2_DIR to be the location of ssh2 library
+#ssh2_DIR = /usr/local/lib
+ssh2_DIR = /usr/lib64

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -25,10 +25,10 @@ TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 #SNCSEQ=$(EPICS_BASE)/../modules/soft/seq
 
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/usr/lib/epics
-ASYN=/usr/lib/epics/asyn4-18
-MOTOR=/usr/lib/epics/motorR6-7-1
-STREAM=/usr/lib/epics/stream2-6
+EPICS_BASE=/usr/local/epics-devel/base-3.15.5
+ASYN=/corvette/home/epics/devel/asyn-4-31
+MOTOR=/corvette/home/epics/devel/motor-6-9
+STREAM=/corvette/home/epics/devel/stream-2-7-7
 
 # Set RULES here if you want to take build rules from somewhere
 # other than EPICS_BASE:

--- a/powerPMACApp/edl/Makefile
+++ b/powerPMACApp/edl/Makefile
@@ -19,7 +19,7 @@ install:
 	cp -f $(TOP)/powerPMACApp/edl/motor-alarms.edl $(TOP)/data/motor-alarms.edl
 	cp -f $(TOP)/powerPMACApp/edl/motor-cmd-confirm.edl $(TOP)/data/motor-cmd-confirm.edl
 
-clean::
+clean:
 	rm -rf $(TOP)/data
 
 include $(TOP)/configure/RULES

--- a/powerPMACApp/opi/Makefile
+++ b/powerPMACApp/opi/Makefile
@@ -6,7 +6,7 @@ install:
 	cp -f $(TOP)/powerPMACApp/opi/powerPMAC.opi $(TOP)/data/powerPMAC.opi
 	cp -f $(TOP)/powerPMACApp/opi/motor.opi $(TOP)/data/motor.opi
 
-clean::
+clean:
 	rm -rf $(TOP)/data
 
 include $(TOP)/configure/RULES

--- a/powerPMACApp/src/Makefile
+++ b/powerPMACApp/src/Makefile
@@ -12,6 +12,8 @@ LIBRARY_IOC += powerPMACSupport
 DBD += powerPMACMotorSSH.dbd
 DBD += drvAsynPowerPMACPort.dbd
 
+# Note: ssh2_DIR should be defined in configure/CONFIG_SITE
+
 # Link locally-provided code into the support library,
 powerPMACSupport_SRCS += sshDriver.cpp
 powerPMACSupport_SRCS += powerPmacController.cpp
@@ -23,7 +25,6 @@ powerPMACSupport_LIBS += asyn
 powerPMACSupport_LIBS += motor
 powerPMACSupport_LIBS += ssh2
 powerPMACSupport_LIBS += $(EPICS_BASE_IOC_LIBS)
-ssh2_DIR = /usr/local/lib
 
 #=============================
 # Build the interactive shell test application
@@ -37,7 +38,6 @@ powerPMACShell_LIBS += powerPMACSupport
 powerPMACShell_LIBS += asyn
 powerPMACShell_LIBS += motor
 powerPMACShell_LIBS += ssh2
-ssh2_DIR = /usr/local/lib
 
 # Finally link to the EPICS Base libraries
 powerPMACShell_LIBS += $(EPICS_BASE_IOC_LIBS)

--- a/powerPMACApp/src/drvAsynPowerPMACPort.dbd
+++ b/powerPMACApp/src/drvAsynPowerPMACPort.dbd
@@ -1,3 +1,2 @@
 registrar(drvAsynPowerPMACPortRegisterCommands)
-include "asyn.dbd"
 

--- a/powerPMACApp/src/powerPmacAxis.cpp
+++ b/powerPMACApp/src/powerPmacAxis.cpp
@@ -106,9 +106,9 @@ asynStatus powerPmacAxis::getAxisInitialStatus(void)
   } else {
     setDoubleParam(pC_->motorLowLimit_,  low_limit*scale_);
     setDoubleParam(pC_->motorHighLimit_, high_limit*scale_);
-    setDoubleParam(pC_->motorPgain_,     pgain);
-    setDoubleParam(pC_->motorIgain_,     igain);
-    setDoubleParam(pC_->motorDgain_,     dgain);
+    setDoubleParam(pC_->motorPGain_,     pgain);
+    setDoubleParam(pC_->motorIGain_,     igain);
+    setDoubleParam(pC_->motorDGain_,     dgain);
     setIntegerParam(pC_->motorStatusHasEncoder_, 1);
   }
   return asynSuccess;

--- a/powerPMACTestApp/src/Makefile
+++ b/powerPMACTestApp/src/Makefile
@@ -13,7 +13,6 @@ DBD += powerPMACTest.dbd
 # powetPMACTest.dbd will be made up from these files:
 powerPMACTest_DBD += base.dbd
 powerPMACTest_DBD += asyn.dbd
-powerPMACTest_DBD += motorRecord.dbd
 powerPMACTest_DBD += motorSupport.dbd
 powerPMACTest_DBD += powerPMACMotorSSH.dbd
 powerPMACTest_DBD += drvAsynPowerPMACPort.dbd

--- a/powerPMACTestApp/src/powerPMACTestMain.cpp
+++ b/powerPMACTestApp/src/powerPMACTestMain.cpp
@@ -1,4 +1,4 @@
-/* powerPMACTestMain.cpp */
+/* _APPNAME_Main.cpp */
 /* Author:  Marty Kraimer Date:    17MAR2000 */
 
 #include <stddef.h>
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "epicsExit.h"
 #include "epicsThread.h"
 #include "iocsh.h"
 
@@ -17,6 +18,6 @@ int main(int argc,char *argv[])
         epicsThreadSleep(.2);
     }
     iocsh(NULL);
+    epicsExit(0);
     return(0);
 }
-


### PR DESCRIPTION
I made changes to allow building on base 3.15 and to be compatible with recent releases of the motor module.

I also moved the definition of ssh2_DIR out of the Makefile and into CONFIG_SITE, since this will be site-specific.